### PR TITLE
DevOpsDays 2018

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -322,6 +322,15 @@
   start-date: 1526342400
   cost: 2
 
+- name: DevOpsDays Kiel
+  url: https://www.devopsdays.org/events/2018-kiel
+  location:
+      city: Kiel
+      country: Germany
+  date: May 16 - 17, 2018
+  start-date: 1526472000
+  cost: 1
+
 - name: ChefConf
   url: https://chefconf.chef.io/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -520,6 +520,15 @@
   start-date: 1537358400
   cost: 1
 
+- name: DevOpsDays Riga
+  url: https://www.devopsdays.org/events/2018-riga
+  location:
+      city: Riga
+      country: Latvia
+  date: September 27 - 28, 2018
+  start-date: 1538049600
+  cost: 1
+
 - name: PuppetConf
   url: https://puppet.com/puppetconf
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -250,6 +250,15 @@
   start-date: 1524571200
   cost: 1
 
+- name: DevOpsDays Jakarta
+  url: https://www.devopsdays.org/events/2018-jakarta
+  location:
+      city: Jakarta
+      country: Indonesia
+  date: April 26 - 27, 2018
+  start-date: 1524744000
+  cost: 1
+
 - name: Interop ITX
   url: https://www.interop.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -178,6 +178,15 @@
   start-date: 1523232001
   cost: 2
 
+- name: DevOpsDays Des Moines
+  url: https://www.devopsdays.org/events/2018-des-moines
+  location:
+      city: Des Moines
+      country: USA
+  date: April 12 - 13, 2018
+  start-date: 1523534400
+  cost: 1
+
 - name: Cloud Foundry Summit
   url: https://www.cloudfoundry.org/event/nasummit2018/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -214,6 +214,15 @@
   start-date: 1524009600
   cost: unknown
 
+- name: DevOpsDays Vancouver
+  url: https://www.devopsdays.org/events/2018-vancouver
+  location:
+      city: Vancouver
+      country: Canada
+  date: April 20 - 21, 2018
+  start-date: 1524225600
+  cost: 1
+
 - name: Interop ITX
   url: https://www.interop.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -331,6 +331,15 @@
   start-date: 1526472000
   cost: 1
 
+- name: DevOpsDays Silicon Valley
+  url: https://www.devopsdays.org/events/2018-silicon-valley/
+  location:
+      city: Mountain View
+      country: USA
+  date: May 17 - 18, 2018
+  start-date: 1526558400
+  cost: 1
+
 - name: ChefConf
   url: https://chefconf.chef.io/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -87,6 +87,15 @@
   date: March 8 - 11, 2018
   start-date: 1520467200
   cost: 1
+
+- name: DevOpsDays Los Angeles
+  url: https://www.devopsdays.org/events/2018-los-angeles
+  location:
+      city: Los Angeles
+      country: USA
+  date: March 9 - 10, 2018
+  start-date: 1520596800
+  cost: 1
   
 - name: ScaleConf
   url: http://scaleconf.org/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -448,6 +448,15 @@
   start-date: 1531396800
   cost: 1
 
+- name: DevOpsDays Indianapolis
+  url: https://www.devopsdays.org/events/2018-indianapolis
+  location:
+      city: Indianapolis
+      country: USA
+  date: July 23 - 24, 2018
+  start-date: 1532347200
+  cost: 1
+
 - name: SREcon18 Europe/Middle East/Africa
   url: https://www.usenix.org/conference/srecon18europe
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -430,6 +430,15 @@
   start-date: 1529884800
   cost: unknown
 
+- name: DevOpsDays Amsterdam
+  url: https://www.devopsdays.org/events/2018-amsterdam
+  location:
+      city: Amsterdam
+      country: Netherlands
+  date: June 27 - 29, 2018
+  start-date: 1530100800
+  cost: 1
+
 - name: SREcon18 Europe/Middle East/Africa
   url: https://www.usenix.org/conference/srecon18europe
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -232,6 +232,15 @@
   start-date: 1524571200
   cost: 1
 
+- name: DevOpsDays Seattle
+  url: https://www.devopsdays.org/events/2018-seattle
+  location:
+      city: Seattle
+      country: USA
+  date: April 24 - 25, 2018
+  start-date: 1524571200
+  cost: 1
+
 - name: Interop ITX
   url: https://www.interop.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -7,6 +7,15 @@
   start-date: 1515974400
   cost: 2
 
+- name: DevOpsDays New York City
+  url: https://www.devopsdays.org/events/2018-new-york-city/
+  location:
+      city: New York City
+      country: USA
+  date: January 18 - 19, 2018
+  start-date: 1516276800
+  cost: 1
+
 - name: DevOps Gathering
   url: https://devops-gathering.io/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -592,6 +592,15 @@
   start-date: 1540684800
   cost: unknown
 
+- name: DevOpsDays Edinburgh
+  url: https://www.devopsdays.org/events/2018-edinburgh
+  location:
+      city: Edinburgh
+      country: Scotland
+  date: November 1 - 2, 2018
+  start-date: 1541073600
+  cost: 1
+
 - name: DevOps East
   url: https://devopseast.techwell.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -574,6 +574,15 @@
   start-date: 1540166400
   cost: unknown
 
+- name: DevOpsDays Philadelphia
+  url: https://www.devopsdays.org/events/2018-philadelphia
+  location:
+      city: Philadelphia
+      country: USA
+  date: October 23 - 24, 2018
+  start-date: 1540296000
+  cost: 1
+
 - name: LISA18
   url: https://www.usenix.org/conference/lisa18
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -439,6 +439,15 @@
   start-date: 1530100800
   cost: 1
 
+- name: DevOpsDays Minneapolis
+  url: https://www.devopsdays.org/events/2018-minneapolis
+  location:
+      city: Minneapolis
+      country: USA
+  date: July 12 - 13, 2018
+  start-date: 1531396800
+  cost: 1
+
 - name: SREcon18 Europe/Middle East/Africa
   url: https://www.usenix.org/conference/srecon18europe
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -223,6 +223,15 @@
   start-date: 1524225600
   cost: 1
 
+- name: DevOpsDays Copenhagen
+  url: https://www.devopsdays.org/events/2018-copenhagen
+  location:
+      city: Copenhagen
+      country: Denmark
+  date: April 24 - 25, 2018
+  start-date: 1524571200
+  cost: 1
+
 - name: Interop ITX
   url: https://www.interop.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -484,6 +484,15 @@
   start-date: 1536537600
   cost: unknown
 
+- name: DevOpsDays Portland
+  url: https://www.devopsdays.org/events/2018-portland
+  location:
+      city: Portland
+      country: USA
+  date: September 11 - 12, 2018
+  start-date: 1536667200
+  cost: 1
+
 - name: Jenkins World 2018
   url: https://www.cloudbees.com/jenkinsworld
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -133,6 +133,15 @@
   start-date: 1521676800
   cost: 2
 
+- name: DevOpsDays Maringá
+  url: https://www.devopsdays.org/events/2018-maringa
+  location:
+      city: Maringá
+      country: Brazil
+  date: March 23 - 24, 2018
+  start-date: 1521806400
+  cost: 1
+
 - name: SREcon18 Americas
   url: https://www.usenix.org/conference/srecon18americas
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -187,6 +187,15 @@
   start-date: 1523534400
   cost: 1
 
+- name: DevOpsDays Atlanta
+  url: https://www.devopsdays.org/events/2018-atlanta
+  location:
+      city: Atlanta
+      country: USA
+  date: April 17 - 18, 2018
+  start-date: 1523966400
+  cost: 1
+
 - name: Cloud Foundry Summit
   url: https://www.cloudfoundry.org/event/nasummit2018/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -43,6 +43,15 @@
   start-date: 1517788800
   cost: free
 
+- name: DevOpsDays Charlotte
+  url: https://www.devopsdays.org/events/2018-charlotte
+  location:
+      city: Charlotte
+      country: USA
+  date: February 22 - 23, 2018
+  start-date: 1519300800
+  cost: 1
+
 - name: ElasticOn
   url: https://www.elastic.co/elasticon/conf/2018/sf
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -466,6 +466,14 @@
   start-date: 1535500800
   cost: unknown
 
+- name: DevOpsDays Raleigh
+  url: https://www.devopsdays.org/events/2018-raleigh
+  location:
+      city: Raleigh
+      country: USA
+  date: September 10 - 11, 2018
+  start-date: 1536580800
+  cost: 1
 
 - name: SaltConf
   url: http://saltconf.com/

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -493,6 +493,15 @@
   start-date: 1536667200
   cost: 1
 
+- name: DevOpsDays Berlin
+  url: https://www.devopsdays.org/events/2018-berlin
+  location:
+      city: Berlin
+      country: Germany
+  date: September 12 - 13, 2018
+  start-date: 1536753600
+  cost: 1
+
 - name: Jenkins World 2018
   url: https://www.cloudbees.com/jenkinsworld
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -349,6 +349,15 @@
   start-date: 1527033600
   cost: 2
 
+- name: DevOpsDays Stockholm
+  url: https://www.devopsdays.org/events/2018-stockholm
+  location:
+      city: Stockholm
+      country: Sweden
+  date: May 24 - 25, 2018
+  start-date: 1527163200
+  cost: 1
+
 - name: DevOpsCon
   url: https://devopsconference.de/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -295,6 +295,15 @@
   start-date: 1525737600
   cost: 2
 
+- name: DevOpsDays Salt Lake city
+  url: https://www.devopsdays.org/events/2018-salt-lake-city
+  location:
+      city: Salt Lake City
+      country: USA
+  date: May 15 - 16, 2018
+  start-date: 1526385600
+  cost: 1
+
 - name: Gartner IT Summit
   url: https://www.gartner.com/events/na/infrastructure-operations-management#
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -367,6 +367,15 @@
   start-date: 1527465600
   cost: 2
 
+- name: DevOpsDays Toronto
+  url: https://www.devopsdays.org/events/2018-toronto
+  location:
+      city: Toronto
+      country: Canada
+  date: May 30 - 31, 2018
+  start-date: 1527681600
+  cost: 1
+
 - name: DevOps West
   url: https://devopswest.techwell.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -511,6 +511,15 @@
   start-date: 1537056000
   cost: unknown
 
+- name: DevOpsDays Columbus
+  url: https://www.devopsdays.org/events/2018-columbus
+  location:
+      city: Columbus
+      country: USA
+  date: September 19 - 20, 2018
+  start-date: 1537358400
+  cost: 1
+
 - name: PuppetConf
   url: https://puppet.com/puppetconf
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -268,6 +268,15 @@
   start-date: 1525046400
   cost: 3
 
+- name: DevOpsDays Zürich
+  url: https://www.devopsdays.org/events/2018-zurich
+  location:
+      city: Zürich
+      country: Switzerland
+  date: May 2 - 3, 2018
+  start-date: 1525262400
+  cost: 1
+
 - name: Red Hat Summit
   url: https://www.redhat.com/en/summit/2018
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -277,6 +277,15 @@
   start-date: 1525262400
   cost: 1
 
+- name: DevOpsDays Austin
+  url: https://www.devopsdays.org/events/2018-austin
+  location:
+      city: Austin
+      country: USA
+  date: May 3 - 4, 2018
+  start-date: 1525348800
+  cost: 1
+
 - name: Red Hat Summit
   url: https://www.redhat.com/en/summit/2018
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -115,6 +115,15 @@
   start-date: 1520589600
   cost: 1
 
+- name: DevOpsDays Baltimore
+  url: https://www.devopsdays.org/events/2018-baltimore
+  location:
+      city: Baltimore
+      country: USA
+  date: March 21 - 22, 2018
+  start-date: 1521633600
+  cost: 1
+
 - name: DevOps Talks
   url: http://devopstalks.com/devops.html
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -196,6 +196,15 @@
   start-date: 1523966400
   cost: 1
 
+- name: DevOpsDays Denver
+  url: https://www.devopsdays.org/events/2018-denver
+  location:
+      city: Denver
+      country: USA
+  date: April 17 - 18, 2018
+  start-date: 1523966400
+  cost: 1
+
 - name: Cloud Foundry Summit
   url: https://www.cloudfoundry.org/event/nasummit2018/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -106,15 +106,6 @@
   start-date: 1520467201
   cost: unknown
 
-- name: DevOpsDay Los Angeles
-  url: http://devopsdays.org/events/2018-los-angeles/
-  location:
-      city: Los Angeles
-      country: USA
-  date: March 9, 2018
-  start-date: 1520589600
-  cost: 1
-
 - name: DevOpsDays Baltimore
   url: https://www.devopsdays.org/events/2018-baltimore
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -241,6 +241,15 @@
   start-date: 1524571200
   cost: 1
 
+- name: DevOpsDays Tokyo
+  url: https://www.devopsdays.org/events/2018-tokyo
+  location:
+      city: Tokyo
+      country: Japan
+  date: April 24 - 25, 2018
+  start-date: 1524571200
+  cost: 1
+
 - name: Interop ITX
   url: https://www.interop.com/
   location:

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -151,6 +151,15 @@
   start-date: 1522108800
   cost: unknown
 
+- name: DevOpsDays Kiev
+  url: https://www.devopsdays.org/events/2018-kiev
+  location:
+      city: Kiev
+      country: Ukraine
+  date: March 31, 2018
+  start-date: 1522497600
+  cost: 1
+
 - name: JAX DevOps
   url: https://devops.jaxlondon.com
   location:


### PR DESCRIPTION
All the worldwide DevOpsDays events as currently listed on devopsdays.org.