### PR TITLE
Added the other QCon Software Conferences

### DIFF
--- a/src/conferences.yml
+++ b/src/conferences.yml
@@ -209,7 +209,7 @@
   cost: 3
 
 - name: QCon New York
-  url: qconnewyork.com
+  url: https://qconnewyork.com/
   location:
     city: New York City
     country: USA

--- a/src/conferences.yml
+++ b/src/conferences.yml
@@ -194,6 +194,48 @@
     fahrenheit: 53
   cost: 3
 
+- name: QCon San Francisco
+  url: https://qconsf.com/
+  location:
+    city: San Francisco
+    country: USA
+    continent: North America
+  date:
+    start: 2019-11-11
+    end: 2019-11-15
+  temperature:
+    celsius: 64
+    fahrenheit: 17
+  cost: 3
+
+- name: QCon New York
+  url: qconnewyork.com
+  location:
+    city: New York City
+    country: USA
+    continent: North America
+  date:
+    start: 2019-6-24
+    end: 2019-6-28
+  temperature:
+    celsius: 80
+    fahrenheit: 26
+  cost: 3
+
+- name: QCon.ai San Francisco
+  url: https://qcon.ai/
+  location:
+    city: San Francisco
+    country: USA
+    continent: North America
+  date:
+    start: 2019-04-16
+    end: 2019-04-17
+  temperature:
+    celsius: 65
+    fahrenheit: 18
+  cost: 3
+
 - name: Incontro DevOps Italia
   url: http://www.incontrodevops.it/events/idi2019/
   location:


### PR DESCRIPTION
QCon London was part of the repo the sibling conferences were. Added
those conferences.

* QConSF is in the bay area and attracts ~1600 sr devs/architects
* QConNYC is in NY and attracts ~100 sr devs/architects
* QCon.ai is a second year ML/AI for SWE conferece in the bay area it
attracts ~300 sr devs/architects

Note: Include QCon.ai because it discusses ml techniques across all
software disciplines, including devops. Ex: ML with CI/CD pipelines,
deploying/AB Testing, & K8/service meshes for ML.

I chair all four software conferences.