### PR TITLE
Fix Monitorama capitalization

### DIFF
--- a/static/conferences.json
+++ b/static/conferences.json
@@ -864,7 +864,7 @@
     "cost": 2
   },
   {
-    "name": "MonitoRama",
+    "name": "Monitorama",
     "url": "http://monitorama.com/",
     "location": {
       "city": "Portland",


### PR DESCRIPTION
The name is not camel-cased.