### PR TITLE
Add Dash conference

### DIFF
--- a/static/conferences.json
+++ b/static/conferences.json
@@ -87,7 +87,7 @@
       "celsius": 26,
       "fahrenheit": 80
     },
-    "cost": 549
+    "cost": 1
   },
   {
     "name": "DevOps Talks Conference Sydney",

--- a/static/conferences.json
+++ b/static/conferences.json
@@ -72,6 +72,24 @@
     "cost": 1
   },
   {
+    "name": "Dash ",
+    "url": "https://www.dashcon.io/",
+    "location": {
+      "city": "New York City",
+      "country": "USA",
+      "continent": "North America"
+    },
+    "date": {
+      "start": "2019-07-16T00:00:00.000Z",
+      "end": "2019-07-17T00:00:00.000Z"
+    },
+    "temperature": {
+      "celsius": 26,
+      "fahrenheit": 80
+    },
+    "cost": 549
+  },
+  {
     "name": "DevOps Talks Conference Sydney",
     "url": "https://devopstalks.com",
     "location": {


### PR DESCRIPTION
Dash is an annual conference about building and scaling the next generation of applications, infrastructure, and technical teams. The two-day conference brings together more than 1,200 engineers across dev and ops who are taking their systems and organizations to the next level of velocity, performance, reliability, and scale. Dash features a mix of speaking sessions, hands-on labs and trainings, and opportunities to make new connections and exchange ideas.